### PR TITLE
Correct a typo

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -23,7 +23,7 @@ body:
       required: true
   - type: textarea
     attributes:
-      label: Additional contex
+      label: Additional context
       description: Add any other context or screenshots about the feature request here.
   - type: input
     attributes:


### PR DESCRIPTION
Correct `Additional contex` to `Additional context`